### PR TITLE
CSS-Version from chayns-components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -185,11 +185,11 @@
       "integrity": "sha512-ATBRyKJw1d2ko+0DWN9+BXau0EK3I/Q6pPzPv3LhJD7r052YFAkAdfb1Bd7ZqhBsJrdse/S7jKxWUOZ61qBD4g=="
     },
     "@fortawesome/fontawesome-svg-core": {
-      "version": "1.2.14",
-      "resolved": "http://repo.tobit.ag:8081/repository/npm/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.14.tgz",
-      "integrity": "sha512-T1qCqkwm9PuvK53J64D1ovfrOTa1kG+SrHNj5cFst/rrskhCnbxpRdbqFIdc/thmXC0ebBX8nOUyja2/mrxe4g==",
+      "version": "1.2.15",
+      "resolved": "http://repo.tobit.ag:8081/repository/npm/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.15.tgz",
+      "integrity": "sha512-M/sHyl4g2VBtKYkay1Z+XImMyTVcaBPmehYtPw4HKD9zg2E7eovB7Yx98aUfZjPbroGqa+IL4/+KhWBMOGlHIQ==",
       "requires": {
-        "@fortawesome/fontawesome-common-types": "^0.2.14"
+        "@fortawesome/fontawesome-common-types": "^0.2.15"
       }
     },
     "@fortawesome/free-brands-svg-icons": {
@@ -1551,19 +1551,6 @@
         "babel-runtime": "^6.22.0"
       }
     },
-    "babel-plugin-transform-imports": {
-      "version": "1.5.1",
-      "resolved": "http://repo.tobit.ag:8081/repository/npm/babel-plugin-transform-imports/-/babel-plugin-transform-imports-1.5.1.tgz",
-      "integrity": "sha512-Jkb0tjqye8kjOD7GdcKJTGB3dC9fruQhwRFZCeYS0sZO2otyjG6SohKR8nZiSm/OvhY+Ny2ktzVE59XKgIqskA==",
-      "requires": {
-        "babel-types": "^6.6.0",
-        "is-valid-path": "^0.1.1",
-        "lodash.camelcase": "^4.3.0",
-        "lodash.findkey": "^4.6.0",
-        "lodash.kebabcase": "^4.1.1",
-        "lodash.snakecase": "^4.1.1"
-      }
-    },
     "babel-plugin-transform-object-rest-spread": {
       "version": "6.26.0",
       "resolved": "http://repo.tobit.ag:8081/repository/npm/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
@@ -1794,6 +1781,7 @@
       "version": "6.26.0",
       "resolved": "http://repo.tobit.ag:8081/repository/npm/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dev": true,
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
@@ -1802,7 +1790,8 @@
         "core-js": {
           "version": "2.5.7",
           "resolved": "http://repo.tobit.ag:8081/repository/npm/core-js/-/core-js-2.5.7.tgz",
-          "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+          "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
+          "dev": true
         }
       }
     },
@@ -1840,6 +1829,7 @@
       "version": "6.26.0",
       "resolved": "http://repo.tobit.ag:8081/repository/npm/babel-types/-/babel-types-6.26.0.tgz",
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+      "dev": true,
       "requires": {
         "babel-runtime": "^6.26.0",
         "esutils": "^2.0.2",
@@ -2322,14 +2312,14 @@
       "dev": true
     },
     "chayns-components": {
-      "version": "4.4.2",
-      "resolved": "http://repo.tobit.ag:8081/repository/npm/chayns-components/-/chayns-components-4.4.2.tgz",
-      "integrity": "sha512-8KvcEYPOSPKO3gcDFs9cVDj2PgHWVyBz8SmoTPMT3dP7rUnZnJUzV7qROKBgZmDh9mpqwWZfaPiTEf8Aw2L41w==",
+      "version": "4.4.3",
+      "resolved": "http://repo.tobit.ag:8081/repository/npm/chayns-components/-/chayns-components-4.4.3.tgz",
+      "integrity": "sha512-Rq0RpU+7XZKJl1hUz4VurEDwC6lqkeWeLYB3AuzEydihYVlVLAjWnVagw2aiq6f+0+TU1GBB7DJQiWPB3qUbBA==",
       "requires": {
-        "@fortawesome/fontawesome-svg-core": "1.2.14",
-        "@fortawesome/free-brands-svg-icons": "5.7.1",
-        "@fortawesome/free-regular-svg-icons": "5.7.1",
-        "@fortawesome/free-solid-svg-icons": "5.7.1",
+        "@fortawesome/fontawesome-svg-core": "^1.2.x",
+        "@fortawesome/free-brands-svg-icons": "^5.7.x",
+        "@fortawesome/free-regular-svg-icons": "^5.7.x",
+        "@fortawesome/free-solid-svg-icons": "^5.7.x",
         "@fortawesome/react-fontawesome": "0.1.4",
         "babel-regenerator-runtime": "^6.5.0",
         "classnames": "^2.2.6",
@@ -2337,41 +2327,32 @@
         "lodash.debounce": "^4.0.8",
         "lodash.isequal": "^4.5.0",
         "lodash.throttle": "^4.1.1",
-        "prop-types": "15.7.1",
+        "prop-types": "^15.0.0",
         "react-transition-group": "2.5.3"
       },
       "dependencies": {
         "@fortawesome/free-brands-svg-icons": {
-          "version": "5.7.1",
-          "resolved": "http://repo.tobit.ag:8081/repository/npm/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-5.7.1.tgz",
-          "integrity": "sha512-YU+np8UJGjHUmzfGS5yyK0wWR0QHbx5lTFRSylBfEkm8QXvOkRxB03sUhOSIWVXU7iPiePuqrsglQRgxoG4nrw==",
+          "version": "5.7.2",
+          "resolved": "http://repo.tobit.ag:8081/repository/npm/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-5.7.2.tgz",
+          "integrity": "sha512-91rIjo00vy7PNrXg5auDsPOSTjmgzc+UUqMyUZHmIrXG5OXMHgjAYMTgEIgs91Lm5XcJtggFZCQz1u5fGFnj2A==",
           "requires": {
-            "@fortawesome/fontawesome-common-types": "^0.2.14"
+            "@fortawesome/fontawesome-common-types": "^0.2.15"
           }
         },
         "@fortawesome/free-regular-svg-icons": {
-          "version": "5.7.1",
-          "resolved": "http://repo.tobit.ag:8081/repository/npm/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-5.7.1.tgz",
-          "integrity": "sha512-JFLJ4M11lZEfi+bmfJdWGVUe5fvmr5k/bqshN7VbJZvEJ6i12Yr6uaByQUM0U1tgw+hJkd8xAwVvKxpJ2HDVTA==",
+          "version": "5.7.2",
+          "resolved": "http://repo.tobit.ag:8081/repository/npm/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-5.7.2.tgz",
+          "integrity": "sha512-ZO+zQcncfT7omTsTIjBkugj/dFXiSnoK44I5p0/WAoNX8aX2Au7j+uxq1qFX4bevkfGFGsPeJUYU1+Q1PB/5pQ==",
           "requires": {
-            "@fortawesome/fontawesome-common-types": "^0.2.14"
+            "@fortawesome/fontawesome-common-types": "^0.2.15"
           }
         },
         "@fortawesome/free-solid-svg-icons": {
-          "version": "5.7.1",
-          "resolved": "http://repo.tobit.ag:8081/repository/npm/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.7.1.tgz",
-          "integrity": "sha512-5V/Q+JoPzuiIHW2JwmZGvE9bHguvNJKa7611DPo51uIvYv9LweX/SnDF+HC23X2W5T3myHhnGi+EZJTmidAmyg==",
+          "version": "5.7.2",
+          "resolved": "http://repo.tobit.ag:8081/repository/npm/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.7.2.tgz",
+          "integrity": "sha512-iujcXMyAvIbWM8W3jkOLpvJbR+rPpdN1QyqhZeJaLRdHPH4JmuovIAYP4vx5Sa1csZVXfRD1eDWqVZ/jGM620A==",
           "requires": {
-            "@fortawesome/fontawesome-common-types": "^0.2.14"
-          }
-        },
-        "prop-types": {
-          "version": "15.7.1",
-          "resolved": "http://repo.tobit.ag:8081/repository/npm/prop-types/-/prop-types-15.7.1.tgz",
-          "integrity": "sha512-f8Lku2z9kERjOCcnDOPm68EBJAO2K00Q5mSgPAUE/gJuBgsYLbVy6owSrtcHj90zt8PvW+z0qaIIgsIhHOa1Qw==",
-          "requires": {
-            "object-assign": "^4.1.1",
-            "react-is": "^16.8.1"
+            "@fortawesome/fontawesome-common-types": "^0.2.15"
           }
         }
       }
@@ -3704,7 +3685,8 @@
     "esutils": {
       "version": "2.0.2",
       "resolved": "http://repo.tobit.ag:8081/repository/npm/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
     },
     "etag": {
       "version": "1.8.1",
@@ -4207,7 +4189,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4228,12 +4211,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4248,17 +4233,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4375,7 +4363,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4387,6 +4376,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4401,6 +4391,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4408,12 +4399,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4432,6 +4425,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4512,7 +4506,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4524,6 +4519,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4609,7 +4605,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4645,6 +4642,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4664,6 +4662,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4707,12 +4706,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -5704,29 +5705,6 @@
         "is-extglob": "^2.1.1"
       }
     },
-    "is-invalid-path": {
-      "version": "0.1.0",
-      "resolved": "http://repo.tobit.ag:8081/repository/npm/is-invalid-path/-/is-invalid-path-0.1.0.tgz",
-      "integrity": "sha1-MHqFWzzxqTi0TqcNLGEQYFNxTzQ=",
-      "requires": {
-        "is-glob": "^2.0.0"
-      },
-      "dependencies": {
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "http://repo.tobit.ag:8081/repository/npm/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "http://repo.tobit.ag:8081/repository/npm/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        }
-      }
-    },
     "is-number": {
       "version": "3.0.0",
       "resolved": "http://repo.tobit.ag:8081/repository/npm/is-number/-/is-number-3.0.0.tgz",
@@ -5824,14 +5802,6 @@
       "resolved": "http://repo.tobit.ag:8081/repository/npm/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
       "dev": true
-    },
-    "is-valid-path": {
-      "version": "0.1.1",
-      "resolved": "http://repo.tobit.ag:8081/repository/npm/is-valid-path/-/is-valid-path-0.1.1.tgz",
-      "integrity": "sha1-EQ+f90w39mPh7HkV60UfLbk6yd8=",
-      "requires": {
-        "is-invalid-path": "^0.1.0"
-      }
     },
     "is-windows": {
       "version": "1.0.2",
@@ -6046,18 +6016,14 @@
     "lodash": {
       "version": "4.17.10",
       "resolved": "http://repo.tobit.ag:8081/repository/npm/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+      "dev": true
     },
     "lodash.assign": {
       "version": "4.2.0",
       "resolved": "http://repo.tobit.ag:8081/repository/npm/lodash.assign/-/lodash.assign-4.2.0.tgz",
       "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
       "dev": true
-    },
-    "lodash.camelcase": {
-      "version": "4.3.0",
-      "resolved": "http://repo.tobit.ag:8081/repository/npm/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
@@ -6070,31 +6036,16 @@
       "resolved": "http://repo.tobit.ag:8081/repository/npm/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
     },
-    "lodash.findkey": {
-      "version": "4.6.0",
-      "resolved": "http://repo.tobit.ag:8081/repository/npm/lodash.findkey/-/lodash.findkey-4.6.0.tgz",
-      "integrity": "sha1-gwWOkDtRy7dZ0JzPVG3qPqOcRxg="
-    },
     "lodash.isequal": {
       "version": "4.5.0",
       "resolved": "http://repo.tobit.ag:8081/repository/npm/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
-    },
-    "lodash.kebabcase": {
-      "version": "4.1.1",
-      "resolved": "http://repo.tobit.ag:8081/repository/npm/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
-      "integrity": "sha1-hImxyw0p/4gZXM7KRI/21swpXDY="
     },
     "lodash.mergewith": {
       "version": "4.6.1",
       "resolved": "http://repo.tobit.ag:8081/repository/npm/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
       "integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==",
       "dev": true
-    },
-    "lodash.snakecase": {
-      "version": "4.1.1",
-      "resolved": "http://repo.tobit.ag:8081/repository/npm/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
-      "integrity": "sha1-OdcUo1NXFHg3rv1ktdy7Fr7Nj40="
     },
     "lodash.tail": {
       "version": "4.1.1",
@@ -7653,11 +7604,6 @@
         "shallowequal": "^1.0.2"
       }
     },
-    "react-is": {
-      "version": "16.8.2",
-      "resolved": "http://repo.tobit.ag:8081/repository/npm/react-is/-/react-is-16.8.2.tgz",
-      "integrity": "sha512-D+NxhSR2HUCjYky1q1DwpNUD44cDpUXzSmmFyC3ug1bClcU/iDNy0YNn1iwme28fn+NFhpA13IndOd42CrFb+Q=="
-    },
     "react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "http://repo.tobit.ag:8081/repository/npm/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
@@ -7750,7 +7696,8 @@
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "http://repo.tobit.ag:8081/repository/npm/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+      "dev": true
     },
     "regenerator-transform": {
       "version": "0.10.1",
@@ -8879,7 +8826,8 @@
     "to-fast-properties": {
       "version": "1.0.3",
       "resolved": "http://repo.tobit.ag:8081/repository/npm/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+      "dev": true
     },
     "to-object-path": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@fortawesome/free-brands-svg-icons": "^5.5.0",
     "@fortawesome/free-regular-svg-icons": "^5.5.0",
     "@fortawesome/free-solid-svg-icons": "^5.5.0",
-    "chayns-components": "^4.4.2",
+    "chayns-components": "^4.4.3",
     "date-fns": "^1.30.1",
     "immutable": "^3.8.2",
     "react": "^16.6.0",

--- a/src/index.dev.html
+++ b/src/index.dev.html
@@ -7,7 +7,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta charset="utf-8">
 
-    <link rel="stylesheet" href="https://api.chayns.net/css/v4.0/">
+    <link rel="stylesheet" href="https://api.chayns.net/css/v<%= CHAYNS_CSS_VERSION %>/">
 
     <title>chayns® React Example</title>
 </head>

--- a/src/index.html
+++ b/src/index.html
@@ -7,7 +7,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta charset="utf-8">
 
-    <link rel="stylesheet" href="https://api.chayns.net/css/v4.0/">
+    <link rel="stylesheet" href="https://api.chayns.net/css/v<%= CHAYNS_CSS_VERSION %>/">
 
     <title>chayns® React Example</title>
 </head>

--- a/src/index.staging.html
+++ b/src/index.staging.html
@@ -7,7 +7,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta charset="utf-8">
 
-    <link rel="stylesheet" href="https://api.chayns.net/css/v4.0/">
+    <link rel="stylesheet" href="https://api.chayns.net/css/v<%= CHAYNS_CSS_VERSION %>/">
 
     <title>chayns® React Example</title>
 </head>

--- a/webpack/dev.babel.js
+++ b/webpack/dev.babel.js
@@ -2,6 +2,8 @@ import path from 'path';
 import fs from 'fs';
 import webpack from 'webpack';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
+import { CHAYNS_CSS_VERSION } from 'chayns-components/lib/constants';
+
 import getBaseConfig from './base-config';
 
 const ROOT_PATH = path.resolve('./');
@@ -34,7 +36,10 @@ export default {
     devtool: 'inline-source-map',
     plugins: [
         new HtmlWebpackPlugin({
-            template: path.resolve(ROOT_PATH, 'src/index.dev.html')
+            template: path.resolve(ROOT_PATH, 'src/index.dev.html'),
+            templateParameters: {
+                CHAYNS_CSS_VERSION,
+            },
         }),
         new webpack.LoaderOptionsPlugin({
             debug: true

--- a/webpack/prod.babel.js
+++ b/webpack/prod.babel.js
@@ -2,6 +2,8 @@ import path from 'path';
 import webpack from 'webpack';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 import AppcacheWebpackPlugin from 'appcache-webpack-plugin';
+import { CHAYNS_CSS_VERSION } from 'chayns-components/lib/constants';
+
 import getBaseConfig from './base-config';
 
 const ROOT_PATH = path.resolve('./');
@@ -10,7 +12,10 @@ export default {
     ...getBaseConfig(false),
     plugins: [
         new HtmlWebpackPlugin({
-            template: path.resolve(ROOT_PATH, 'src/index.html')
+            template: path.resolve(ROOT_PATH, 'src/index.html'),
+            templateParameters: {
+                CHAYNS_CSS_VERSION,
+            },
         }),
         new AppcacheWebpackPlugin({
             cache: [

--- a/webpack/staging.babel.js
+++ b/webpack/staging.babel.js
@@ -2,6 +2,8 @@ import path from 'path';
 import webpack from 'webpack';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 import AppcacheWebpackPlugin from 'appcache-webpack-plugin';
+import { CHAYNS_CSS_VERSION } from 'chayns-components/lib/constants';
+
 import getBaseConfig from './base-config';
 
 const ROOT_PATH = path.resolve('./');
@@ -11,7 +13,10 @@ export default {
     devtool: 'hidden-source-map',
     plugins: [
         new HtmlWebpackPlugin({
-            template: path.resolve(ROOT_PATH, 'src/index.staging.html')
+            template: path.resolve(ROOT_PATH, 'src/index.staging.html'),
+            templateParameters: {
+                CHAYNS_CSS_VERSION,
+            },
         }),
         new AppcacheWebpackPlugin({
             cache: [


### PR DESCRIPTION
This PR synchronizes the used chayns-css version with the version that is required by chayns-components. It only works with chayns-components >= 4.4.1.